### PR TITLE
DONT MERGE [Part 3] Add rekor client for transparent logging of timestamp changes

### DIFF
--- a/tuf-ite2/repository/rekor.py
+++ b/tuf-ite2/repository/rekor.py
@@ -1,0 +1,69 @@
+"""Client for our TUF repository to upload metadata to Rekor using rekor-cli."""
+
+import re
+import subprocess
+import tempfile
+
+class RekorClient:
+    """
+    RekorClient is a client for our TUF repository to upload metadata to Rekor using rekor-cli.
+    It has convenience methods to upload metadata to Rekor and to retrieve logs from Rekor.
+    """
+    UPLOAD_MESSAGE = r"Created entry at index (\d+), available at: (\S+)"
+    
+    def __init__(self, tuf_repo_url, key_dir) -> None:
+        """Initializes the RekorUploader object with the URL of the TUF repository."""
+
+        # TODO: allow running against a self-hosted Rekor server
+        # for now we will use the Sigstore managed Rekor server
+        self.tuf_repo_url = tuf_repo_url
+        self.key_dir = key_dir
+
+        self.logs: tuple[int, str] = []
+
+    def upload(self, root: bytes, metadata: bytes):
+        """Uploads the metadata with given root public key to Rekor."""
+
+        # Download root key into a temporary file
+        with tempfile.TemporaryDirectory() as temp_dir:
+
+            with open(f"{temp_dir}/root.json", "wb") as f:
+                f.write(root)
+
+            with open(f"{temp_dir}/metadata.json", "wb") as f:
+                f.write(metadata)
+
+            # Upload metadata to Rekor
+            try:
+                output = subprocess.run([
+                    "rekor-cli",
+                    "upload",
+                    "--type",
+                    "tuf",
+                    "--artifact",
+                    f"{temp_dir}/metadata.json",
+                    "--public-key",
+                    f"{temp_dir}/root.json",
+                ],
+                check=True, capture_output=True)
+
+                print(f"Uploaded metadata to Rekor: {output.stdout.decode()}")
+
+            except subprocess.CalledProcessError as e:
+                print(f"Failed to upload metadata to Rekor: {e}")
+
+        output = output.stdout.decode()
+        match = re.search(self.UPLOAD_MESSAGE, output)
+
+        self.logs.append((int(match.group(1)), match.group(2)))
+
+    def get_logs(self) -> list[dict]:
+        """Returns the logs from Rekor as a list of dictionaries."""
+
+        return [
+            {
+                "Log Index": log[0],
+                "Log URL": log[1],
+            }
+            for log in self.logs
+        ]

--- a/tuf-ite2/repository/repo
+++ b/tuf-ite2/repository/repo
@@ -10,6 +10,7 @@ live repository by adding new target files periodically.
 """
 
 import argparse
+import json
 import logging
 import sys
 from datetime import datetime
@@ -60,6 +61,9 @@ class ReqHandler(BaseHTTPRequestHandler):
             )
         elif self.path.startswith("/targets/"):
             data = self.get_target(self.path[len("/targets/") :])
+        elif self.path == "/api/audit":
+            logs: list[dict] = self.server.repo.rekor_client.get_logs()
+            data = json.dumps(logs, indent=4).encode()
 
         if data is None:
             self.send_error(404)


### PR DESCRIPTION
Changes:
- Added `RekorClient`
  - `upload` can be used by the repository server on timestamp changes to sign and upload a log to Rekor
  - `get_logs` for retrieving the in-memory cache of logs saved to Rekor (for convenience, you would probably want to persist this to a DB somewhere or leverage search functionality)
- Added new API to server `/api/audit` which calls `get_logs` and returns it in a nice format
- Simple repository close() will call `upload` with root metadata and timetamp metadata for uploading to Rekor
  
![Screenshot 2024-12-17 at 1 39 08 AM](https://github.com/user-attachments/assets/7f80f7a1-2090-4968-baf4-52cf28d53459)
